### PR TITLE
Create BaseErrorClass, PubSubErrorClass and unit testing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,13 @@
 {
     "presets": ["es2015", "stage-0"],
-    "plugins": ["transform-es2015-arrow-functions", "transform-async-to-generator", "transform-es2015-destructuring"],
+    "plugins": [
+      "transform-es2015-arrow-functions",
+      "transform-async-to-generator",
+      "transform-es2015-destructuring",
+      ["babel-plugin-transform-builtin-classes", {
+        "globals": ["Error"]
+      }]
+    ],
     "env": {
       "test": {
         "presets": ["es2015", "stage-0"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The JavaScript SDK for developers(including third party developers/vendors) to c
 
 The SDK is under active development, we will release the latest version to npm as soon as we have new services ready.
 
-The current version of this SDK is **0.0.56**
+The current version of this SDK is **0.0.57**
 
 To install CarPal SDK: **npm i --save carpal**
 
@@ -45,7 +45,7 @@ If you were using webpack and had encountered the ***regeneratorRuntime is not d
 | Module                             | Method                                            | Description                                                          |
 | ---------------------------------- |---------------------------------------------------| ---------------------------------------------------------------------|
 | carpal/dist/data/validation/Schema | getSchemaAsync(service, schemaName)              | This returns a Promise object with the a schema. This function should be called before calling the **validate** function |
-| carpal/dist/data/validation/Schema | validate = (schema, payload)              | This returns true if all fields in **schema** are covered by **payload** object, otherwise it returns false. This function currently only checks field names, we will implement the data type check soon |
+| carpal/dist/data/validation/Schema | validate = (schema, payload)              | This returns true if all fields in **schema** are covered by **payload** object, otherwise it returns false. This function checks both field names and data types|
 
 # Public
 | Module                             | Method                                            | Description                                                          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carpal",
-  "version": "0.0.55",
+  "version": "0.0.57",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ably": "^1.0.8",
     "aws-sdk": "^2.161.0",
     "axios": "^0.17.0",
+    "babel-plugin-transform-builtin-classes": "^0.4.0",
     "camelize": "^1.0.0",
     "lodash": "^4.17.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carpal",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "The SDK for CarPal fleet solution development.",
   "main": "dist/build.js",
   "scripts": {

--- a/src/data/error/BaseError.js
+++ b/src/data/error/BaseError.js
@@ -1,0 +1,8 @@
+'use strict';
+
+export default class BaseError extends Error {
+  constructor(...args) {
+    super(...args);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/data/error/PubSubError.js
+++ b/src/data/error/PubSubError.js
@@ -1,0 +1,7 @@
+import BaseError from './BaseError'
+
+export default class PubSubError extends BaseError {
+  constructor(message) {
+    super(message || 'Something went wrong in PubSub!');
+  }
+}

--- a/src/data/error/__test__/pubsubError.test.js
+++ b/src/data/error/__test__/pubsubError.test.js
@@ -1,0 +1,11 @@
+import PubSubError from '../PubSubError';
+
+function doPubSubError() {
+  throw new PubSubError();
+}
+
+it('should recognize pubsub error', () => {
+  expect(() => {
+      doPubSubError();
+  }).toThrowError();
+});

--- a/src/data/messaging/PubSub.js
+++ b/src/data/messaging/PubSub.js
@@ -26,7 +26,7 @@ export const pubsub = (key, channel, realtime=true)=>{
     var client = realtime?new Ably.Realtime(key):new Ably.Rest(key);
     var chan = client.channels.get(channel);
     return {
-        publish: (event, message)=>{        
+        publish: (event, message)=>{
             chan.publish(event, message);
         },
 
@@ -34,9 +34,12 @@ export const pubsub = (key, channel, realtime=true)=>{
             chan.subscribe(event, callback);
         },
 
+        unsubscribe: (event, listener) => {
+            chan.unsubscribe(event, listener);
+        },
+
         history: (callback) => {
             chan.history(callback);
         }
     }
 }
-

--- a/src/data/validation/Schema.js
+++ b/src/data/validation/Schema.js
@@ -12,8 +12,6 @@ export const getSchemaAsync = async (service, schemaName)=>{
 }
 
 export const validate = (schema, payload)=>{
-    const payloadKeys = Object.keys(payload);
-    //To further enhance this function, we need to validate the data type
-    //of the value according to schema
-    return !Object.keys(schema).some((val)=>payloadKeys.indexOf(val) === -1);    
+    const schemaKeys = Object.keys(schema);
+    return Object.entries(payload).every(([key, value]) => schemaKeys.includes(key) && typeof value === schema[key]);
 }

--- a/src/data/validation/__test__/schema.test.js
+++ b/src/data/validation/__test__/schema.test.js
@@ -1,37 +1,41 @@
 import { getSchemaAsync, validate } from '../Schema';
 
-test('Test for retrieving schema by service and schema name', async () =>{
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-    const response = await getSchemaAsync('pubsub', 'orders');
-
-    expect(response.fields).toBeTruthy();
-})
+describe('Test for retrieving schema by service and schema name', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+  const schemaTypes = [{domain: 'customer', type: 'dashboard-order'}];
+  schemaTypes.forEach((element) => {
+    it(`${element.domain} - ${element.type}`, async () => {
+       const response = await getSchemaAsync(element.domain, element.type);
+       expect(response.properties).toBeTruthy();
+    });
+  });
+});
 
 test('Test for comparison of schema and payload', async () =>{
-    let schema = {"order_id": "Number",
-                    "order_status_id": "Number", 
-                    "pickup_date": "String", 
-                    "latitude": "String", 
-                    "longitude": "String", 
-                    "driver_id": "Number", 
-                    "driver_name": "String"};
+    let schema = {"order_id": "number",
+                    "order_status_id": "number",
+                    "pickup_date": "string",
+                    "latitude": "string",
+                    "longitude": "string",
+                    "driver_id": "number",
+                    "driver_name": "string"};
 
     const payload = {"order_id": 123,
-                     "order_status_id": 1, 
-                     "pickup_date": "2017-12-01", 
-                     "latitude": "103.2340123", 
-                     "longitude": "1.230491", 
-                     "driver_id": 1, 
+                     "order_status_id": 1,
+                     "pickup_date": "2017-12-01",
+                     "latitude": "103.2340123",
+                     "longitude": "1.230491",
+                     "driver_id": 1,
                      "driver_name": "Driver A"};
+
     expect(validate(schema, payload)).toBeTruthy();
 
-    schema = {"order_id": "Number",
-              "order_status_id": "Number", 
-              "pickup_date": "String", 
-              "latitude": "String", 
-              "longitude": "String", 
-              "driver_id": "Number", 
-              "driver_name": "String",
-              "customer_id": "Number"};
+    schema = {"order_id": "string",
+              "order_status_id": "number",
+              "pickup_date": "string",
+              "latitude": undefined,
+              "longitude": "string",
+              "driver_id": "number",
+              "driver_name": "string"};
     expect(validate(schema, payload)).toBe(false);
 })


### PR DESCRIPTION
- Create BaseError Class
- Create PubSubError Class which extends BaseError Class
- Unit Testing for PubSubError Class
- Add new babel transform plugin which can help to extends JS Built-in Class such as Error, Array. 
- Validate Schema data type & field names
- Update test case for getSchemaAsync