### PR TITLE
[EB-2936] fix for getJobsAsync method - not working with params

### DIFF
--- a/src/data/customer/Job.js
+++ b/src/data/customer/Job.js
@@ -22,7 +22,10 @@ export const getJobsAsync = async (token, filterObject = {}) => {
   try {
     const jobs = await axios({
       method: 'GET',
-      url: `${endpoints.API_V3.JOB.replace('{0}', paramString)}`,
+      url: `${endpoints.API_V3.JOB.replace(
+        '{0}',
+        paramString.replace('&', '?')
+      )}`,
       headers: { Authorization: `Bearer ${token}` },
     });
 


### PR DESCRIPTION
Fix for param string creator, I thought that it will always add `?` at the beginning so replacing `&` misleaded me, I thought that it is for something else. So in the end it should be there.